### PR TITLE
Fixed case-sensitive fs defect when requiring advanced JSON parser

### DIFF
--- a/lib/oanda_api/streaming/json_parser.rb
+++ b/lib/oanda_api/streaming/json_parser.rb
@@ -10,6 +10,11 @@ module OandaAPI
     module JsonParser
       extend self
 
+      REQUIREMENT_MAP = {
+        gson: "gson",
+        yajl: "yajl"
+      }
+
       # Loads (if not already loaded) and returns the current adapter class.
       # @return [.parse] a class implementing a `.parse` method
       def adapter
@@ -86,7 +91,7 @@ module OandaAPI
         end
 
         begin
-          require sym.to_s
+          require REQUIREMENT_MAP.get sym
           return sym
         rescue ::LoadError
           warning

--- a/lib/oanda_api/streaming/json_parser.rb
+++ b/lib/oanda_api/streaming/json_parser.rb
@@ -10,12 +10,6 @@ module OandaAPI
     module JsonParser
       extend self
 
-      # Map parser adapters to the gem library they require.
-      REQUIREMENT_MAP = {
-        gson: "Gson",
-        yajl: "Yajl"
-      }
-
       # Loads (if not already loaded) and returns the current adapter class.
       # @return [.parse] a class implementing a `.parse` method
       def adapter
@@ -88,10 +82,11 @@ module OandaAPI
         begin
           return sym if Kernel.const_get sym.to_s.capitalize
         rescue ::NameError
+          nil
         end
 
         begin
-          require REQUIREMENT_MAP.fetch sym
+          require sym.to_s
           return sym
         rescue ::LoadError
           warning

--- a/lib/oanda_api/streaming/json_parser.rb
+++ b/lib/oanda_api/streaming/json_parser.rb
@@ -10,6 +10,7 @@ module OandaAPI
     module JsonParser
       extend self
 
+      # Map parser adapters to the gem library they require.
       REQUIREMENT_MAP = {
         gson: "gson",
         yajl: "yajl"
@@ -91,7 +92,7 @@ module OandaAPI
         end
 
         begin
-          require REQUIREMENT_MAP.get sym
+          require REQUIREMENT_MAP.fetch sym
           return sym
         rescue ::LoadError
           warning


### PR DESCRIPTION
Tripped over this issue just now and it was a bit tricky to track down. I (as well as you I am assuming) do most of my development on a Mac OS X system and have been using this advanced parser logic for a few weeks in development on my Mac with no issues.

Today I pull the latest code down to my Linux VPS and attempted to run and got a load error on Yajl. Worked on Mac but not on Linux. What got me onto the right path with troubleshooting was attempting the following in irb.

```
2.2.1 :001 > require 'Yajl'
LoadError: cannot load such file -- Yajl
	from /home/user/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from /home/user/.rvm/rubies/ruby-2.2.1/lib/ruby/site_ruby/2.2.0/rubygems/core_ext/kernel_require.rb:54:in `require'
	from (irb):1
	from /home/user/.rvm/rubies/ruby-2.2.1/bin/irb:11:in `<main>'
2.2.1 :002 > require 'yajl'
 => true 
```

Mac OS X FS by default is case-insensitive so Yajl == yajl but not on Linux.