### PR TITLE
Updated request rate throttling to throttle across multiple threads

### DIFF
--- a/lib/oanda_api/client/client.rb
+++ b/lib/oanda_api/client/client.rb
@@ -129,27 +129,12 @@ module OandaAPI
     # if {OandaAPI::Configuration#use_request_throttling?} is enabled.
     #
     # @return [void]
-#    def self.throttle_request_rate
-#      return unless OandaAPI.configuration.use_request_throttling?
-#
-#      now = Time.now
-#      Thread.current[:oanda_api_last_request_at] ||= now
-#
-#      min_interval = OandaAPI.configuration.min_request_interval
-#      thread_count = Thread.list.select{|t| t[:oanda_api_last_request_at]}.count
-#
-#      min_threaded_interval = min_interval * thread_count
-#      delta = now - Thread.current[:oanda_api_last_request_at]
-#
-#      _throttle(now, min_threaded_interval) if delta < min_threaded_interval
-#      Thread.current[:oanda_api_last_request_at] = Time.now
-#    end
     def self.throttle_request_rate
       now = Time.now
       delta = now - (last_request_at || now)
       _throttle(now) if delta < OandaAPI.configuration.min_request_interval &&
                                 OandaAPI.configuration.use_request_throttling?
-      last_request_at = Time.now
+      self.last_request_at = Time.now
     end
 
     # @private
@@ -160,7 +145,6 @@ module OandaAPI
     #
     # @return [nil] if a request has never been throttled.
     def self.last_throttled_at
-      #Thread.current[:oanda_api_throttled_at]
       @throttled_at
     end
 
@@ -175,7 +159,6 @@ module OandaAPI
     #
     # @return [void]
     def self._throttle(time)
-      #Thread.current[:oanda_api_throttled_at] = time
       @mutex.synchronize { @throttled_at = time }
       sleep OandaAPI.configuration.min_request_interval
     end

--- a/lib/oanda_api/client/client.rb
+++ b/lib/oanda_api/client/client.rb
@@ -144,7 +144,7 @@ module OandaAPI
 #      _throttle(now, min_threaded_interval) if delta < min_threaded_interval
 #      Thread.current[:oanda_api_last_request_at] = Time.now
 #    end
-    def self.self.throttle_request_rate
+    def self.throttle_request_rate
       now = Time.now
       delta = now - (last_request_at || now)
       _throttle(now) if delta < OandaAPI.configuration.min_request_interval &&

--- a/lib/oanda_api/client/client.rb
+++ b/lib/oanda_api/client/client.rb
@@ -16,7 +16,9 @@ module OandaAPI
     include HTTParty
     persistent_connection_adapter idle_timeout: 10,
                                   keep_alive: 30,
-                                  pool_size: 10
+                                  pool_size: OandaAPI.configuration.connection_pool_size
+
+    @mutex = Mutex.new
 
     # Use a custom JSON parser
     parser OandaAPI::Client::JsonParser
@@ -112,26 +114,42 @@ module OandaAPI
       end
     end
 
+    def self.last_request_at
+      @last_request_at
+    end
+
+    def self.last_request_at=(value)
+      Thread.current[:last_request_at] = value
+      @mutex.synchronize { @last_request_at = value }
+    end
+
     # @private
     # Limits the execution rate of consecutive requests. Specified by
     # {OandaAPI::Configuration#max_requests_per_second}. Only enforced
     # if {OandaAPI::Configuration#use_request_throttling?} is enabled.
     #
     # @return [void]
-    def self.throttle_request_rate
-      return unless OandaAPI.configuration.use_request_throttling?
-
+#    def self.throttle_request_rate
+#      return unless OandaAPI.configuration.use_request_throttling?
+#
+#      now = Time.now
+#      Thread.current[:oanda_api_last_request_at] ||= now
+#
+#      min_interval = OandaAPI.configuration.min_request_interval
+#      thread_count = Thread.list.select{|t| t[:oanda_api_last_request_at]}.count
+#
+#      min_threaded_interval = min_interval * thread_count
+#      delta = now - Thread.current[:oanda_api_last_request_at]
+#
+#      _throttle(now, min_threaded_interval) if delta < min_threaded_interval
+#      Thread.current[:oanda_api_last_request_at] = Time.now
+#    end
+    def self.self.throttle_request_rate
       now = Time.now
-      Thread.current[:oanda_api_last_request_at] ||= now
-
-      min_interval = OandaAPI.configuration.min_request_interval
-      thread_count = Thread.list.select{|t| t[:oanda_api_last_request_at]}.count
-
-      min_threaded_interval = min_interval * thread_count
-      delta = now - Thread.current[:oanda_api_last_request_at]
-
-      _throttle(now, min_threaded_interval) if delta < min_threaded_interval
-      Thread.current[:oanda_api_last_request_at] = Time.now
+      delta = now - (last_request_at || now)
+      _throttle(now) if delta < OandaAPI.configuration.min_request_interval &&
+                                OandaAPI.configuration.use_request_throttling?
+      last_request_at = Time.now
     end
 
     # @private
@@ -142,7 +160,8 @@ module OandaAPI
     #
     # @return [nil] if a request has never been throttled.
     def self.last_throttled_at
-      Thread.current[:oanda_api_throttled_at]
+      #Thread.current[:oanda_api_throttled_at]
+      @throttled_at
     end
 
     private
@@ -155,9 +174,10 @@ module OandaAPI
     # @param [Time] interval The time that the thread must sleep.
     #
     # @return [void]
-    def self._throttle(time, interval)
-      Thread.current[:oanda_api_throttled_at] = time
-      sleep interval
+    def self._throttle(time)
+      #Thread.current[:oanda_api_throttled_at] = time
+      @mutex.synchronize { @throttled_at = time }
+      sleep OandaAPI.configuration.min_request_interval
     end
 
     # @private

--- a/lib/oanda_api/client/client.rb
+++ b/lib/oanda_api/client/client.rb
@@ -16,7 +16,7 @@ module OandaAPI
     include HTTParty
     persistent_connection_adapter idle_timeout: 10,
                                   keep_alive: 30,
-                                  pool_size: 2
+                                  pool_size: 10
 
     # Use a custom JSON parser
     parser OandaAPI::Client::JsonParser

--- a/lib/oanda_api/configuration.rb
+++ b/lib/oanda_api/configuration.rb
@@ -49,7 +49,8 @@ module OandaAPI
     # @return [Float]
     def min_request_interval
       connections = Thread.list.select{|thr| thr[:last_request_at]}.count
-      @min_request_interval ||= (connections.to_f / max_requests_per_second)
+      connections += 1 if connections == 0
+      @min_request_interval = (connections.to_f / max_requests_per_second)
     end
 
     # The number of seconds the client waits for a new HTTP connection to be established before

--- a/lib/oanda_api/configuration.rb
+++ b/lib/oanda_api/configuration.rb
@@ -10,6 +10,7 @@ module OandaAPI
     REST_API_VERSION        = "v1"
     USE_COMPRESSION         = false
     USE_REQUEST_THROTTLING  = false
+    CONNECTION_POOL_SIZE    = 10
 
     # The format in which dates will be returned by the API (`:rfc3339` or `:unix`).
     # See the Oanda Development Guide for more details about {http://developer.oanda.com/rest-live/development-guide/#date_Time_Format DateTime formats}.
@@ -47,7 +48,8 @@ module OandaAPI
     # Determined by {#max_requests_per_second}. Only enforced if {#use_request_throttling?} is `true`.
     # @return [Float]
     def min_request_interval
-      @min_request_interval ||= (1.0 / max_requests_per_second)
+      connections = Thread.list.select{|thr| thr[:last_request_at]}.count
+      @min_request_interval ||= (connections.to_f / max_requests_per_second)
     end
 
     # The number of seconds the client waits for a new HTTP connection to be established before
@@ -132,6 +134,16 @@ module OandaAPI
     # @return [void]
     def use_request_throttling=(value)
       @use_request_throttling = !!value
+    end
+
+    # Maximum size of the persistent connection pool
+    def connection_pool_size
+      @connection_pool_size or CONNECTION_POOL_SIZE
+    end
+
+    # Define the maximum size of the persistent connection pool
+    def connection_pool_size=(value)
+      @connection_pool_size = !!value
     end
 
     # @private


### PR DESCRIPTION
Regarding pool_size...

Oanda only limits new connections to 2 per second. More than 2 can be maintained.