### PR TITLE
Fix for thread-level throttling

### DIFF
--- a/lib/oanda_api/client/token_client.rb
+++ b/lib/oanda_api/client/token_client.rb
@@ -48,6 +48,7 @@ module OandaAPI
         @default_params = {}
         self.domain = domain
         @headers = auth
+        load_persistent_connection_adapter
       end
 
       # Parameters used for authentication.

--- a/lib/oanda_api/client/username_client.rb
+++ b/lib/oanda_api/client/username_client.rb
@@ -41,6 +41,8 @@ module OandaAPI
         @username = username
         @default_params = auth
         @headers = {}
+
+        load_persistent_connection_adapter
       end
 
       # Parameters used for authentication.

--- a/lib/oanda_api/configuration.rb
+++ b/lib/oanda_api/configuration.rb
@@ -10,6 +10,7 @@ module OandaAPI
     REST_API_VERSION        = "v1"
     USE_COMPRESSION         = false
     USE_REQUEST_THROTTLING  = false
+    CONNECTION_POOL_SIZE    = 2
 
     # The format in which dates will be returned by the API (`:rfc3339` or `:unix`).
     # See the Oanda Development Guide for more details about {http://developer.oanda.com/rest-live/development-guide/#date_Time_Format DateTime formats}.
@@ -132,6 +133,17 @@ module OandaAPI
     # @return [void]
     def use_request_throttling=(value)
       @use_request_throttling = !!value
+    end
+
+    # Maximum size of the persistent connection pool
+    def connection_pool_size
+      @connection_pool_size = CONNECTION_POOL_SIZE if @connection_pool_size.nil?
+      @connection_pool_size
+    end
+
+    # Define the maximum size of the persistent connection pool
+    def connection_pool_size=(value)
+      @connection_pool_size = value
     end
 
     # @private

--- a/lib/oanda_api/version.rb
+++ b/lib/oanda_api/version.rb
@@ -1,3 +1,3 @@
 module OandaAPI
-  VERSION = "0.9.3"
+  VERSION = "0.9.4"
 end


### PR DESCRIPTION
Abandoned connection-level throttling since I finally received a response from Oanda stating that their limit is applied to the API key (auth_token). Connection count does not matter. It is limited across all threads and all connections.
- Updated `Configuration` with connection pool size
- Moved persistent connection adapter binding to instance method to pass configuration options
- Updated `Client#throttle_request_rate` to pass delta to `Client#_throttle`
- Updated `Client#_throttle` to accept delta and only sleep the difference between min request rate and delta
- Updated `Client#_throttle` to sleep inside of mutex else throttling does nothing
- Bumped version to 0.9.4

The fix here deals with sleeping inside of the mutex. Sleeping outside does nothing for throttling. The rest are enhancements to pass connection pool size in config and to only sleep the proper length of time.
