### PR TITLE
Fixed to show heartbeat in stream.

### DIFF
--- a/lib/oanda_api/streaming/client.rb
+++ b/lib/oanda_api/streaming/client.rb
@@ -132,6 +132,7 @@ module OandaAPI
                                                                 uri: api_uri(path),
                                                                 query: Utils.stringify_keys(conditions),
                                                                 headers: OandaAPI.configuration.headers.merge(headers)
+          @streaming_request.emit_heartbeats = emit_heartbeats?
           @streaming_request.stream(&block)
           return nil
         end


### PR DESCRIPTION
`Streaming::Client` and `Streaming::Request` have the field `emit_heartbeats` , but `Client` didn't pass it to `Request`. It caused that `Heartbeat` were not shown.


You can check it by this code:
```ruby
client = OandaAPI::Streaming::Client.new(:practice, ENV.fetch("OANDA_PRACTICE_TOKEN")) 
client.emit_heartbeats = true
prices = client.prices(account_id: 1234, instruments: %w[AUD_CAD AUD_CHF])
prices.stream do |price|
  # Note: The code in this block should handle the price
  #       as efficiently as possible, otherwise the connection could timeout.
  #       For example, you could publish the tick on a queue to be handled
  #       by some other thread or process.
  price  # => OandaAPI::Resource::Price
end
``` 