### PR TITLE
Fixed request rate throttle logic issues

### DIFF
--- a/lib/oanda_api/client/client.rb
+++ b/lib/oanda_api/client/client.rb
@@ -159,10 +159,15 @@ module OandaAPI
     #
     # @return [void]
     def self.throttle_request_rate
+      last_request_time = last_request_at
       now = Time.now
-      delta = now - (last_request_at || now)
-      _throttle(delta, now) if delta < OandaAPI.configuration.min_request_interval &&
-                                       OandaAPI.configuration.use_request_throttling?
+
+      if last_request_time
+        delta = now - last_request_time
+        _throttle(delta, now) if delta < OandaAPI.configuration.min_request_interval &&
+                                         OandaAPI.configuration.use_request_throttling?
+      end
+
       self.last_request_at = Time.now
     end
 


### PR DESCRIPTION
The recent fix of the lack of a receiver on the write of `last_request_at` resulted in a race condition where `now` was set before the blocking call to `last_request_at` in the `delta` calculation which resulted in some returned values of `last_request_at` to be after `now` (due to queued threads on the mutex) so `now - later` resulted in a negative millisecond count which then grew even more negative in the call to `_throttle` since the already negative number was then subtracted again from the min request interval causing the threads to sleep longer and longer which caused the next iteration to be even more in the future and so on.

On a good note, Oanda increased the request rate to 30 per second instead of the 15 it used to be! :-)

In testing this, I was able to get 25 req/s with 10 threads and 10 connections in the pool but any more started to trigger the 30 req/s violation response from the broker. Either this logic is still off with enough threads to cause some drift or the logic the broker uses to calculate the req/s for each API key is a bit off.