### PR TITLE
Fix incorrect option keys for http timeout.

### DIFF
--- a/lib/oanda_api/client/client.rb
+++ b/lib/oanda_api/client/client.rb
@@ -116,7 +116,8 @@ module OandaAPI
                     params_key    => Utils.stringify_keys(conditions.merge(default_params)),
                     :headers      => OandaAPI.configuration.headers.merge(headers),
                     :open_timeout => OandaAPI.configuration.open_timeout,
-                    :read_timeout => OandaAPI.configuration.read_timeout
+                    :read_timeout => OandaAPI.configuration.read_timeout,
+                    :timeout      => OandaAPI.configuration.open_timeout
       end
 
       handle_response response, resource_descriptor


### PR DESCRIPTION
`:read_timeout` and `:open_timeout` is used as option keys for http request, but `:timeout` is used in persistent_httparty, and the options are ignored. [(see this code.)](https://github.com/soupmatt/persistent_httparty/blob/master/lib/httparty/persistent/connection_adapter.rb#L18)

In haste, I create a pull request which fix this problem, Please merge it if you think it good. I decided to use the configuration value of `:open_timeout`, but it may be better to add a different configuration.