### PR TITLE
Fix call to load http-exceptions

### DIFF
--- a/lib/oanda_api/client/client.rb
+++ b/lib/oanda_api/client/client.rb
@@ -14,6 +14,7 @@ module OandaAPI
   # - Uses request rate limiting if enabled (see {Configuration#use_request_throttling}).
   module Client
     include HTTParty
+    include Http
 
     # Used to synchronize throttling metrics
     @throttle_mutex = Mutex.new
@@ -108,7 +109,7 @@ module OandaAPI
       method = Client.map_method_to_http_verb method
       resource_descriptor = ResourceDescriptor.new path, method
 
-      response = Http::Exceptions.wrap_and_check do
+      response = Exceptions.wrap_and_check do
         params_key = [:post, :patch, :put].include?(method) ? :body : :query
         Client.throttle_request_rate
         Client.send method,
@@ -121,7 +122,7 @@ module OandaAPI
       end
 
       handle_response response, resource_descriptor
-      rescue Http::Exceptions::HttpException => e
+      rescue Exceptions::HttpException => e
         raise OandaAPI::RequestError, e.message
     end
 


### PR DESCRIPTION
Patched only to work fine because no idea to fix root of bug. If you have any better idea, please tell me.

failed when:
```ruby
client = OandaAPI::Client::TokenClient.new(env, token)
client.account(account)
      .order(instrument: instrument, type: :market,
             side: order.sell_or_buy, units: order.unit)
      .create
```
```
NameError: uninitialized constant HTTP::Exceptions
Did you mean?  Exception
from /home/ubuntu/vendor/bundle/ruby/2.4.0/gems/oanda_api-0.9.5/lib/oanda_api/client/client.rb:123:in `rescue in execute_request'
```

- Ubuntu 16.04.2 LTS
- ruby 2.4.1p111 (2017-03-22 revision 58053) [x86_64-linux] 